### PR TITLE
Merge the object structs branch into the main branch

### DIFF
--- a/ktrace/s_mat_prop.c
+++ b/ktrace/s_mat_prop.c
@@ -1,0 +1,16 @@
+//Copied over from the main.c file
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> /* Strlen and stuff */
+#include <math.h>
+#include <time.h> /* srandom(time(null)) */
+
+
+typedef struct mat_properties_struct { //Create struct which has the current properties of object color and roughness. 
+
+	char o_color[128];	
+	double o_roughness; 
+
+}s_mat_properties; 
+
+ 

--- a/ktrace/s_mat_prop.c
+++ b/ktrace/s_mat_prop.c
@@ -8,7 +8,10 @@
 
 typedef struct mat_properties_struct { //Create struct which has the current properties of object color and roughness. 
 
-	char o_color[128];	
+	//char o_color[128];
+	char o_color_r[3];
+	char o_color_g[3];
+	char o_color_b[3];	
 	double o_roughness; 
 
 }s_mat_properties; 


### PR DESCRIPTION
I added object property related structs to the code:
> o_color_r|g|b - It holds the color value of the object, like 000(red) 255(blue) 000(green), making the object blue in color. 
> o_roughness - This holds the roughness value of an object as a float, whether it should be shiny or not, like 42.42 which is an object which is between shiny and rough. 

This all is located under a struct called `s_mat_properties` in the future (from the `e_s` branch) I'll add it to the header file, but for this current moment none of the header files have anything in them.

I know this is a very bad description, I made this in a hurry and please see this and merge it. 